### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "name": "YouTube Downloader",
     "type": "app",
+    "instance_version": "6.15.60",
     "version": "2.0.0",
     "categories": [
         "import",
@@ -9,7 +10,7 @@
         "data transformation"
     ],
     "description": "Downloads and trim video from Youtube.",
-    "docker_image": "supervisely/import-export:0.0.5",
+    "docker_image": "supervisely/import-export:6.73.564",
     "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
     "port": 8000,
     "icon": "https://user-images.githubusercontent.com/115161827/226860080-a91b9f16-2b34-4563-9dcf-95bb0acf4c00.jpg",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-supervisely==6.72.154
+supervisely==6.73.564
 #==6.72.42
 google-api-python-client==2.81.0
 moviepy==1.0.3


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
